### PR TITLE
docs: clean up stale xsltproc references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,6 @@
 /config.status
 /configure
 
-/doc/html.xsl
-/doc/manpages.xsl
-/doc/jemalloc.xml
 /doc/jemalloc.html
 /doc/jemalloc.3
 

--- a/INSTALL.adoc
+++ b/INSTALL.adoc
@@ -29,9 +29,8 @@ You can uninstall the installed build artifacts like this:
 make uninstall
 ----
 
-NOTE: `autoconf` needs to be installed. Documentation is built by the default
-target only when `xsltproc` is available. Build will warn but not stop if the
-dependency is missing.
+NOTE: `autoconf` needs to be installed. Documentation is built only when
+`JEMALLOC_ENABLE_DOC=ON` is passed to CMake and `asciidoctor` is available.
 
 == Building with CMake
 
@@ -86,7 +85,7 @@ All jemalloc features can be configured via CMake options:
 
 |`JEMALLOC_ENABLE_DOC`
 |`OFF`
-|Build documentation (requires xsltproc)
+|Build documentation (requires asciidoctor)
 
 |`CMAKE_INSTALL_PREFIX`
 |`/usr/local`


### PR DESCRIPTION
Follow-up to #22.

The asciidoc migration PR deleted `doc/jemalloc.xml.in`, `doc/html.xsl.in`, `doc/manpages.xsl.in`, and `doc/stylesheet.xsl`, but left references to those names in two tracked files:

- `.gitignore` had `/doc/html.xsl`, `/doc/manpages.xsl`, `/doc/jemalloc.xml` entries for files that no longer exist (sources deleted, generation flow gone). Removed. The `/doc/jemalloc.html` and `/doc/jemalloc.3` entries stay — they catch manually-generated outputs.
- `INSTALL.adoc` said docs require `xsltproc` and are built by the default target. Now says `asciidoctor` and `JEMALLOC_ENABLE_DOC=ON`, matching the actual post-migration flow.

No code changes.
