### PR TITLE
docs: announce supported platforms near the top of README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -35,6 +35,23 @@ While the original project is frozen, this fork continues to:
 * Address bugs reported by the community
 
 
+== Supported platforms
+
+jemalloc runs on every major desktop, server, mobile, and embedded OS in use
+today:
+
+* *Linux* (glibc + musl) — x64, ARM64, x86 (cross-compile)
+* *Windows* (MSVC + MinGW) — x64, x86, ARM64
+* *macOS* — Intel + Apple Silicon (ARM64)
+* *FreeBSD* — x64
+* *Linux RISC-V* — riscv64
+* *HarmonyOS PC (OHOS)* — ARM64 (`aarch64-linux-ohos`)
+
+CMake and vcpkg are the recommended integration paths for all of the above.
+See link:#platform-support-matrix[Platform support matrix] for the full
+breakdown of compilers, CI coverage, and package-manager status.
+
+
 == Installation
 
 === Quick start
@@ -410,6 +427,7 @@ printf("Pointer %p has %zu-byte alignment\n", p, alignment);
 ----
 
 
+[#platform-support-matrix]
 == Platform support
 
 [cols="1,2,2,1,1,1",options="header"]


### PR DESCRIPTION
Adds a prominent "Supported platforms" announcement section near the top of README.adoc (right after Purpose), so a reader scanning the header immediately sees what platforms jemalloc supports.

- Six platform families, one bullet each: Linux (glibc + musl), Windows, macOS, FreeBSD, Linux RISC-V, HarmonyOS PC (OHOS).
- The OHOS row was added to the matrix in #25 but was not surfaced anywhere visible at the top.
- Adds a `[#platform-support-matrix]` anchor to the existing detailed table so the new top-level announcement can link into it without duplicating the table.

Pure docs change, no code impact.
