### PR TITLE
fix(release): add pull_request trigger so tag-and-release can fire

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,9 @@ on:
         required: true
         type: boolean
         default: true
+  pull_request:
+    types: [closed]
+    branches: [main]
 
 jobs:
   validate-and-bump:


### PR DESCRIPTION
## Problem

The `tag-and-release` job's condition is:
```yaml
if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release')
```

But the workflow only declared a `workflow_dispatch` trigger — no `pull_request`. So `github.event.pull_request` was always undefined and `tag-and-release` could never run, no matter how many release PRs were merged.

Discovered when PR #28 (Release v5.6.0, with `release` label) merged successfully but no tag and no GitHub release was produced.

## Fix

Add the missing trigger:
```yaml
pull_request:
  types: [closed]
  branches: [main]
```

The job's existing label check ensures it only fires for PRs labeled `release`, so ordinary PR closes still skip it.

## Test plan

- [ ] Merge this PR.
- [ ] Re-trigger `release.yml` with `next_version=patch` to cut the next release (5.6.1, since 5.6.0 is already on main but untagged).
- [ ] Merge the resulting release PR.
- [ ] Verify `tag-and-release` runs and creates the tag + GitHub release.
