### PR TITLE
fix(release): gate bump/create-pr on workflow_dispatch only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,7 @@ on:
 jobs:
   validate-and-bump:
     name: Validate and bump version
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-24.04
     outputs:
       version: ${{ steps.get_version.outputs.version }}
@@ -110,6 +111,7 @@ jobs:
 
   create-pr:
     name: Create release PR
+    if: github.event_name == 'workflow_dispatch'
     needs: validate-and-bump
     runs-on: ubuntu-24.04
 


### PR DESCRIPTION
## Problem

PR #29 added the missing `pull_request` trigger so `tag-and-release` could fire. But that exposed a second bug: `validate-and-bump` and `create-pr` have no `if:` condition, so they also run on the `pull_request` event.

When PR #31 (Release v5.6.0) merged, run `30194680672` queued both `validate-and-bump` AND `tag-and-release`. The former would have:
- Read the latest git tag (`v5.5.0`, since v5.6.0 doesn't exist yet).
- Bumped to `5.5.1`.
- Pushed a new `release/v5.5.1` branch.
- Opened *another* release PR.

Recursive release PRs on every merge. Caught and cancelled before the runner allocated.

## Fix

Gate both jobs on `github.event_name == 'workflow_dispatch'`:

```yaml
validate-and-bump:
  if: github.event_name == 'workflow_dispatch'
  ...

create-pr:
  if: github.event_name == 'workflow_dispatch'
  ...
```

The `pull_request` event now only fires `tag-and-release` (whose own condition checks `pull_request.merged && release label`).

## Test plan

- [ ] Merge this fix.
- [ ] Re-merge (or reopen+merge) PR #31 — actually since #31 already merged, manually trigger a release.
- [ ] Verify only `tag-and-release` runs on the merge, not `validate-and-bump`.
