### PR TITLE
Release v5.6.0 (tag)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,4 @@
-* 5.6.0 (July 26, 2026)
+* 5.6.0 (July 26, 2026) - tagged
 
   Tebako fork release focused on platform expansion, documentation
   modernization, and release-automation hardening.


### PR DESCRIPTION
Triggers the tag-and-release job to publish the v5.6.0 tag and GitHub release. The workflow is now correctly gated on workflow_dispatch for validate-and-bump/create-pr.