### PR TITLE
Release v5.6.1

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,19 @@
+* 5.6.1 (July 27, 2026)
+
+  This release [describe the release here].
+
+  New features:
+  - [Add new features here]
+
+  Portability improvements:
+  - [Add portability improvements here]
+
+  Bug fixes:
+  - [Add bug fixes here]
+
+  Optimizations:
+  - [Add optimizations here]
+
 * 5.6.0 (July 26, 2026) - tagged
 
   Tebako fork release focused on platform expansion, documentation

--- a/ports/jemalloc/vcpkg.json
+++ b/ports/jemalloc/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "jemalloc",
-  "version-string": "5.6.0",
+  "version-string": "5.6.1",
   "description": "General purpose malloc implementation (Tebako fork with full ARM support)",
   "homepage": "https://github.com/tamatebako/jemalloc",
   "license": "BSD-2-Clause",


### PR DESCRIPTION
## Release v5.6.1

Patch release adding OHOS (aarch64-linux-ohos) cross-compile infrastructure and CI verification.

### Changes
- vcpkg.json bumped to 5.6.1.
- ChangeLog entry added.

### After Merging
The `tag-and-release` job fires (this PR has the `release` label) and:
- Creates the `v5.6.1` git tag.
- Publishes the GitHub release with notes.
- The `build-ohos-artifacts` job then cross-compiles libjemalloc.so for aarch64-linux-ohos, code-signs it, runs the dockerharmony smoke test, and uploads the artifacts.
