### PR TITLE
Release v5.6.3

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,19 @@
+* 5.6.3 (July 27, 2026)
+
+  This release [describe the release here].
+
+  New features:
+  - [Add new features here]
+
+  Portability improvements:
+  - [Add portability improvements here]
+
+  Bug fixes:
+  - [Add bug fixes here]
+
+  Optimizations:
+  - [Add optimizations here]
+
 * 5.6.2 (July 27, 2026)
 
   This release [describe the release here].

--- a/ports/jemalloc/vcpkg.json
+++ b/ports/jemalloc/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "jemalloc",
-  "version-string": "5.6.2",
+  "version-string": "5.6.3",
   "description": "General purpose malloc implementation (Tebako fork with full ARM support)",
   "homepage": "https://github.com/tamatebako/jemalloc",
   "license": "BSD-2-Clause",


### PR DESCRIPTION
Patch release to fix the OHOS smoke-test step in release.yml (PR #38). Triggers build-ohos-artifacts for signed libjemalloc.so aarch64-linux-ohos.