### PR TITLE
ci(riscv): mark riscv-configure-flags matrix as continue-on-error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -795,12 +795,17 @@ jobs:
           ctest --output-on-failure
 
   # Level 2: RISC-V configure flags (runs after smoke tests succeed)
-  # NOTE: QEMU emulation is significantly slower - tests take longer than native
+  # NOTE: QEMU emulation is significantly slower - tests take longer than native.
+  # continue-on-error: these jobs pull docker images (tonistiigi/binfmt via
+  # uraimo/run-on-arch-action) and Docker Hub timeouts occasionally cause
+  # spurious failures. The Level-1 `riscv` smoke job already gates merging;
+  # these flag-combo jobs are bonus coverage.
   riscv-configure-flags:
     name: RISC-V flags - ${{ matrix.flags }}
     runs-on: ubuntu-latest
     needs: [riscv, test-cmake-builds, test-vcpkg-integration]
     timeout-minutes: 90
+    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
RISC-V flags matrix failed on 2026-07-27 due to a Docker Hub network timeout when uraimo/run-on-arch-action pulled tonistiigi/binfmt. Transient infrastructure flakiness shouldn't gate merges. Level-1 `riscv` smoke job still gates; this matrix is bonus coverage.